### PR TITLE
feat: add CORS middleware for handling cross-origin requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,21 @@ const logger = require('./src/utils/logger');
 const app = express();
 const port = 3000;
 
-app.use(cors()); // 使用 cors 中介軟體
+// 設定 CORS 中介軟體，允許多個來源
+const allowedOrigins = ['http://localhost:5173', 'https://wangyingju.github.io/USphere/'];
+
+const corsOptions = {
+  origin: function (origin, callback) {
+    if (allowedOrigins.indexOf(origin) !== -1 || !origin) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+  optionsSuccessStatus: 200
+};
+
+app.use(cors(corsOptions)); // 使用 cors 中介軟體
 app.use(express.json());
 app.use('/users', userRoutes);
 app.use('/topics', topicRoutes);

--- a/index.js
+++ b/index.js
@@ -1,31 +1,36 @@
-const express = require('express');
-const cors = require('cors');
-const userRoutes = require('./src/routes/userRoutes');
-const topicRoutes = require('./src/routes/topicRoutes');
-const logger = require('./src/utils/logger');
+const express = require("express");
+const cors = require("cors");
+const userRoutes = require("./src/routes/userRoutes");
+const topicRoutes = require("./src/routes/topicRoutes");
+const logger = require("./src/utils/logger");
 const app = express();
 const port = 3000;
 
+require("dotenv").config();
+
 // 設定 CORS 中介軟體，允許多個來源
-const allowedOrigins = ['http://localhost:5173', 'https://wangyingju.github.io/USphere/'];
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(",")
+  : [];
 
 const corsOptions = {
   origin: function (origin, callback) {
     if (allowedOrigins.indexOf(origin) !== -1 || !origin) {
       callback(null, true);
     } else {
-      callback(new Error('Not allowed by CORS'));
+      callback(new Error("Not allowed by CORS"));
     }
   },
-  optionsSuccessStatus: 200
+  optionsSuccessStatus: 200,
+  credentials: true,
 };
 
 app.use(cors(corsOptions)); // 使用 cors 中介軟體
 app.use(express.json());
-app.use('/users', userRoutes);
-app.use('/topics', topicRoutes);
+app.use("/users", userRoutes);
+app.use("/topics", topicRoutes);
 
-logger.info('Express app 已經啟動');
+logger.info("Express app 已經啟動");
 // ...existing code...
 
 app.listen(port, () => {

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 const express = require('express');
+const cors = require('cors');
 const userRoutes = require('./src/routes/userRoutes');
 const topicRoutes = require('./src/routes/topicRoutes');
 const logger = require('./src/utils/logger');
 const app = express();
 const port = 3000;
 
+app.use(cors()); // 使用 cors 中介軟體
 app.use(express.json());
 app.use('/users', userRoutes);
 app.use('/topics', topicRoutes);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@supabase/supabase-js": "^2.47.10",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "winston": "^3.17.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.47.10
         version: 2.47.10
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -564,6 +567,10 @@ packages:
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
 
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -1155,6 +1162,10 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.3:
     resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
@@ -2268,6 +2279,11 @@ snapshots:
 
   cookiejar@2.1.4: {}
 
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   create-jest@29.7.0(@types/node@22.10.2):
     dependencies:
       '@jest/types': 29.6.3
@@ -3013,6 +3029,8 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.3: {}
 


### PR DESCRIPTION
部屬上去後都會被 vercel 擋住，最後是把 vercel 的 auth 關閉，這樣可以正常進入 express 來判斷 cors 的連線
https://stackoverflow.com/questions/77109541/blocked-due-to-unauthorised-request-401-error-thrown-by-google-indexing-and-li