### PR TITLE
Fix topic editing rights in query

### DIFF
--- a/src/services/topicService.js
+++ b/src/services/topicService.js
@@ -55,10 +55,15 @@ exports.getAllTopics = async (query, token) => {
   const { data, error } = await dbQuery;
 
   if (!token || userError) {
-    data.map((topic) => ({
+    // `map` returns a new array but the result wasn't used, leaving
+    // `can_edit_topics` unchanged. Assign the mapped array so callers
+    // receive the modified topics list.
+    const topics = (data || []).map((topic) => ({
       ...topic,
       can_edit_topics: false,
     }));
+    if (error) throw new Error(error.message);
+    return topics;
   }
   if (error) throw new Error(error.message);
 


### PR DESCRIPTION
## Summary
- ensure unauthenticated topic queries correctly disable edit rights

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624fb798488325ace1ffc146b10b0b